### PR TITLE
Added a hint about what to do with special words

### DIFF
--- a/courses/ruby-primer/06-level-loops/04-title-case-program/instructions.md
+++ b/courses/ruby-primer/06-level-loops/04-title-case-program/instructions.md
@@ -3,7 +3,7 @@
 1. Define a method named `fix_title`.
 2. The method should take a string argument that represents the title of a book.
 3. The method should return a properly-capitalized string which represents the book title.
-4. Certain words are only capitalized if they are the first word in the title: "a", "and", "the", and "of".
+4. Certain words are only capitalized if they are the first word in the title: "a", "and", "the", and "of".  Hint: Creating a reference to these as an array held in a variable to check is useful.
 
 The completed method can be called like this:
 


### PR DESCRIPTION
This provides no insight at all:
Certain words are only capitalized if they are the first word in the title: "a", "and", "the", and "of".

Many students have no idea they need to create a variable to reference.  So I'm sure telling them to use `include?` on some array would likely confuse many to think since we're splitting the title, that that's what you should call it on.