### PR TITLE
Fix bug in Js Primer / Syntax / Logical Operators exercise

### DIFF
--- a/courses/javascript-primer/01-syntax/18-logical-operators/solution.js
+++ b/courses/javascript-primer/01-syntax/18-logical-operators/solution.js
@@ -1,7 +1,7 @@
 <!--{ ids:[143], language:'JavaScript', type:'workshop', order: 17, name:'Logical Operators', description:'Test the relationship between two boolean values' } -->
 var logical1;
 var logical2;
-var logical3 = (true === 1) || (false === 0);
+var logical3 = (true == 1) || (false == 0);
 var logical4 = !0;
 var logical5;
 var logical6;

--- a/courses/javascript-primer/01-syntax/18-logical-operators/starting_code.js
+++ b/courses/javascript-primer/01-syntax/18-logical-operators/starting_code.js
@@ -1,7 +1,7 @@
 <!--{ ids:[143], language:'JavaScript', type:'workshop', order: 17, name:'Logical Operators', description:'Test the relationship between two boolean values' } -->
 var logical1 = true && false;
 var logical2 = !(2 > 1);
-var logical3 = (true === 1) || (false === 0);
+var logical3 = (true == 1) || (false == 0);
 var logical4 = !0;
 var logical5 = ('') && 0;
 var logical6 = (3 > 5) || (4 < 1);


### PR DESCRIPTION
Based on the spec, `logical3` is expected to evaluate to `true`, but it evaluates to `false`. Comparison operators changed so that it evaluates to `true`.